### PR TITLE
Passing tests in all time zones

### DIFF
--- a/sun_time.gemspec
+++ b/sun_time.gemspec
@@ -26,10 +26,13 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<hoe>, [">= 2.3.2"])
+      s.add_development_dependency(%q<newgem>, [">= 1.5.3"])
     else
       s.add_dependency(%q<hoe>, [">= 2.3.2"])
+      s.add_dependency(%q<newgem>, [">= 1.5.3"])
     end
   else
     s.add_dependency(%q<hoe>, [">= 2.3.2"])
+    s.add_dependency(%q<newgem>, [">= 1.5.3"])
   end
 end

--- a/test/test_date_ext.rb
+++ b/test/test_date_ext.rb
@@ -10,12 +10,12 @@ class TestDate < Test::Unit::TestCase
   end
   
   def test_sunrise
-    sunrise = Time.mktime(2009, 7, 23, 4, 50, 32)
+    sunrise = Time.utc(2009, 7, 23, 2, 50, 32)
     assert_equal(sunrise, @date.sunrise(@lat, @lng))
   end
   
   def test_sunset
-    sunset =  Time.mktime(2009, 7, 23, 21, 48, 56)
+    sunset =  Time.utc(2009, 7, 23, 19, 48, 56)
   
     assert_equal(sunset, @date.sunset(@lat, @lng))
   end

--- a/test/test_sun_time.rb
+++ b/test/test_sun_time.rb
@@ -11,13 +11,13 @@ class TestSunTime < Test::Unit::TestCase
   end
   
   def test_sunrise
-    sunrise = Time.mktime(2009, 7, 23, 4, 50, 32)
+    sunrise = Time.utc(2009, 7, 23, 2, 50, 32)
     
     assert_equal(sunrise, @sun_time.sunrise)
   end
   
   def test_sunset
-    sunset =  Time.mktime(2009, 7, 23, 21, 48, 56)
+    sunset =  Time.utc(2009, 7, 23, 19, 48, 56)
   
     assert_equal(sunset, @sun_time.sunset)
   end


### PR DESCRIPTION
I was attempting to update this gem for 1.9.3 compliance, however I found the test were not passing for me on 1.8.7 or 1.9.2. 

It looks like the test was timezone dependent because it was setting the expected date using Time.mktime which is really the same as Time.local.

I also had a hard time getting the tests running, so I added newgem as a development dependency for easier future contributions.

If you can verify that these test changes are indeed the intended behavior I will open another pull request for 1.9.3.
