### PR TITLE
Sunrise/sunset calculation infinite loop fix

### DIFF
--- a/lib/sun_time.rb
+++ b/lib/sun_time.rb
@@ -4,6 +4,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "sun_time/degree_trig
 
 class SunTime
   VERSION = '0.0.1'
+  MEAN_SOLAR_ANOMALY_DELTA = 0.000001
   
   class AlwaysDarkError < ::StandardError; end
   class AlwaysLightError < ::StandardError; end
@@ -97,7 +98,7 @@ private
   def recalculate_m
     current_m = m(j_transit)
     last_m = nil
-    until current_m == last_m
+    until close_enough(current_m, last_m)
       last_m = current_m
       current_m = m(j_transit(last_m))
     end
@@ -127,4 +128,13 @@ private
     twelve_hour_offset_in_seconds = 12*60*60
     Time.utc(dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec) + twelve_hour_offset_in_seconds
   end 
+
+  private
+
+  # There are some edge cases where comparing values was never returning true.
+  # This gets around that by ensuring they are "close enough"
+  def close_enough(actual, expected)
+    return false if expected.nil?
+    (actual - expected).abs <= MEAN_SOLAR_ANOMALY_DELTA
+  end
 end

--- a/lib/sun_time.rb
+++ b/lib/sun_time.rb
@@ -129,8 +129,6 @@ private
     Time.utc(dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec) + twelve_hour_offset_in_seconds
   end 
 
-  private
-
   # There are some edge cases where comparing values was never returning true.
   # This gets around that by ensuring they are "close enough"
   def close_enough(actual, expected)

--- a/test/test_sun_time.rb
+++ b/test/test_sun_time.rb
@@ -33,6 +33,12 @@ class TestSunTime < Test::Unit::TestCase
     assert_nil(winter_in_sweden.sunrise)
     assert_nil(winter_in_sweden.sunset)
   end
+
+  def test_infinite_loop
+    sunrise = Time.utc(2012, 4, 24, 10, 4, 51)
+    infinite_loop_location = SunTime.new(Date.new(2012,4,24), 40.9674702, -74.2278852)
+    assert_equal(sunrise, infinite_loop_location.sunrise)
+  end
   
   # Private methods
   


### PR DESCRIPTION
Some combos of date/lat/lng cause an infinite loop when comparing mean solar anomaly. This checks that they are "close enough"

https://github.com/elabs/sun_time/issues/1
